### PR TITLE
Crash fix when dropping PE files.

### DIFF
--- a/qiew.py
+++ b/qiew.py
@@ -629,10 +629,10 @@ class WHeaders(QtWidgets.QDialog):
             for i in range(l//20 + 1):
                 L.insert((i+0)*20 + i, '\n')
             
-            open(name + '.drop' + '.hex', 'wb').write(' '.join(L))
+            open(name + '.drop' + '.hex', 'w').write(' '.join(L))
 
         if self.ui.rpe.isChecked() == True:
-            text = 'MZ'
+            text = b'MZ'
 
             M = []
             idx = 0
@@ -658,7 +658,7 @@ class WHeaders(QtWidgets.QDialog):
             for mz in M:
                 # try to make an PE instance
                 try:
-                    pe = pefile.PE(data=str(dataModel.getStream(mz, size)))
+                    pe = pefile.PE(data=dataModel.getStream(mz, size))
                 except pefile.PEFormatError as e:
                     continue
 


### PR DESCRIPTION
Each commit fixes a different crash for the PE file plugin. I leave here a resume of the error logs.

1. Dropping as hex
```
open(name + '.drop' + '.hex', 'wb').write(' '.join(L))
TypeError: a bytes-like object is required, not 'str'
```

2. Dropping as PE
```
idx = page.find(text, idx, size)
TypeError: a bytes-like object is required, not 'str'
```
```
pe = pefile.PE(data=str(dataModel.getStream(mz, size)))
...
for byte, byte_count in Counter(bytearray(self.__data__)).items():
TypeError: string argument without an encoding
```
